### PR TITLE
Add Option "Allow any food to sick resting animals"

### DIFF
--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -93,7 +93,7 @@
   <PawnRules.Dialog_Global.Title>Global Options</PawnRules.Dialog_Global.Title>
   <PawnRules.Dialog_Global.AllowEmergencyFood>Allow any food when malnourished</PawnRules.Dialog_Global.AllowEmergencyFood>
   <PawnRules.Dialog_Global.AllowTrainingFood>Allow any food when training</PawnRules.Dialog_Global.AllowTrainingFood>
-  <PawnRules.Dialog_Global.AllowRestingFood>Allow any food to resting animals</PawnRules.Dialog_Global.AllowRestingFood>
+  <PawnRules.Dialog_Global.AllowRestingFood>Allow any food to sick resting animals</PawnRules.Dialog_Global.AllowRestingFood>
   <PawnRules.Dialog_Global.AllowDrugsRestriction>Allow drugs to be restricted</PawnRules.Dialog_Global.AllowDrugsRestriction>
   <PawnRules.Dialog_Global.ShowRule>Show {0}</PawnRules.Dialog_Global.ShowRule>
   <PawnRules.Dialog_Global.Plans>Import/Export Plans</PawnRules.Dialog_Global.Plans>

--- a/Languages/English/Keyed/Keys.xml
+++ b/Languages/English/Keyed/Keys.xml
@@ -93,6 +93,7 @@
   <PawnRules.Dialog_Global.Title>Global Options</PawnRules.Dialog_Global.Title>
   <PawnRules.Dialog_Global.AllowEmergencyFood>Allow any food when malnourished</PawnRules.Dialog_Global.AllowEmergencyFood>
   <PawnRules.Dialog_Global.AllowTrainingFood>Allow any food when training</PawnRules.Dialog_Global.AllowTrainingFood>
+  <PawnRules.Dialog_Global.AllowRestingFood>Allow any food to resting animals</PawnRules.Dialog_Global.AllowRestingFood>
   <PawnRules.Dialog_Global.AllowDrugsRestriction>Allow drugs to be restricted</PawnRules.Dialog_Global.AllowDrugsRestriction>
   <PawnRules.Dialog_Global.ShowRule>Show {0}</PawnRules.Dialog_Global.ShowRule>
   <PawnRules.Dialog_Global.Plans>Import/Export Plans</PawnRules.Dialog_Global.Plans>

--- a/Source/Data/Registry.cs
+++ b/Source/Data/Registry.cs
@@ -31,6 +31,7 @@ namespace PawnRules.Data
         public static bool AllowDrugsRestriction { get => _instance._allowDrugsRestriction; set => _instance._allowDrugsRestriction = value; }
         public static bool AllowEmergencyFood { get => _instance._allowEmergencyFood; set => _instance._allowEmergencyFood = value; }
         public static bool AllowTrainingFood { get => _instance._allowTrainingFood; set => _instance._allowTrainingFood = value; }
+        public static bool AllowRestingFood { get => _instance._allowRestingFood; set => _instance._allowRestingFood = value; }
         public static Pawn ExemptedTrainer { get => _instance._exemptedTrainer; set => _instance._exemptedTrainer = value; }
 
         private string _loadedVersion;
@@ -52,6 +53,7 @@ namespace PawnRules.Data
         private bool _allowDrugsRestriction;
         private bool _allowEmergencyFood;
         private bool _allowTrainingFood;
+        private bool _allowRestingFood;
 
         private Pawn _exemptedTrainer;
 
@@ -325,6 +327,7 @@ namespace PawnRules.Data
             Scribe_Values.Look(ref _allowDrugsRestriction, "allowDrugsRestriction");
             Scribe_Values.Look(ref _allowEmergencyFood, "allowEmergencyFood");
             Scribe_Values.Look(ref _allowTrainingFood, "allowTrainingFood");
+            Scribe_Values.Look(ref _allowRestingFood, "allowRestingFood");
 
             Scribe_Collections.Look(ref _savedPresets, "presets", LookMode.Deep);
             Scribe_Collections.Look(ref _savedBindings, "bindings", LookMode.Deep);

--- a/Source/Interface/Dialog_Global.cs
+++ b/Source/Interface/Dialog_Global.cs
@@ -19,6 +19,7 @@ namespace PawnRules.Interface
             Registry.AllowDrugsRestriction = listing.CheckboxLabeled(Lang.Get("Dialog_Global.AllowDrugsRestriction"), Registry.AllowDrugsRestriction);
             Registry.AllowEmergencyFood = listing.CheckboxLabeled(Lang.Get("Dialog_Global.AllowEmergencyFood"), Registry.AllowEmergencyFood);
             Registry.AllowTrainingFood = listing.CheckboxLabeled(Lang.Get("Dialog_Global.AllowTrainingFood"), Registry.AllowTrainingFood);
+            Registry.AllowRestingFood = listing.CheckboxLabeled(Lang.Get("Dialog_Global.AllowRestingFood"), Registry.AllowRestingFood);
 
             listing.Gap();
             listing.GapLine();

--- a/Source/Patch/RimWorld_FoodUtility_WillEat.cs
+++ b/Source/Patch/RimWorld_FoodUtility_WillEat.cs
@@ -24,6 +24,8 @@ namespace PawnRules.Patch
 
                 if (Registry.AllowTrainingFood && (getter?.CurJobDef != null) && ((getter.CurJobDef == JobDefOf.Tame) || (getter.CurJobDef == JobDefOf.Train))) { return; }
 
+                if (Registry.AllowRestingFood && (getter?.CurJobDef != null) && (getter.CurJobDef == JobDefOf.FeedPatient)) { return; }
+
                 if (!p.RaceProps.CanEverEat(food)) { return; }
 
                 var restriction = p.GetRules()?.GetRestriction(RestrictionType.Food);

--- a/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
+++ b/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
@@ -10,7 +10,7 @@ namespace PawnRules.Patch
     {
         private static void Prefix(Pawn pawn, Thing t)
         {
-            if (!Registry.IsActive || !Registry.AllowRestingFood || !(t is Pawn) || ((t as Pawn).training is null)) { return; }
+            if (!Registry.IsActive || !Registry.AllowRestingFood || !SickAnimalUtility.IsThingASickRestingAnimal(t)) { return; }
 
             Registry.ExemptedTrainer = pawn;
         }
@@ -28,7 +28,7 @@ namespace PawnRules.Patch
     {
         private static void Prefix(Pawn pawn, Thing t)
         {
-            if (!Registry.IsActive || !Registry.AllowRestingFood || !(t is Pawn) || ((t as Pawn).training is null)) { return; }
+            if (!Registry.IsActive || !Registry.AllowRestingFood || !SickAnimalUtility.IsThingASickRestingAnimal(t)) { return; }
 
             Registry.ExemptedTrainer = pawn;
         }
@@ -38,6 +38,29 @@ namespace PawnRules.Patch
             if (!Registry.IsActive || (Registry.ExemptedTrainer == null)) { return; }
 
             Registry.ExemptedTrainer = null;
+        }
+    }
+
+    public static class SickAnimalUtility
+    {
+        public static bool IsThingASickRestingAnimal(Thing t)
+        {
+            if (t is Pawn)
+            {
+                Pawn p = t as Pawn;
+                return (p.training != null) && (DoesPawnHaveImmunityDisease(p) || !CanPawnWalk(p));
+            }
+            return false;
+        }
+
+        private static bool DoesPawnHaveImmunityDisease(Pawn p)
+        {
+            return p.health.hediffSet.HasImmunizableNotImmuneHediff();
+        }
+
+        private static bool CanPawnWalk(Pawn p)
+        {
+            return p.health.capacities.CapableOf(PawnCapacityDefOf.Moving);
         }
     }
 

--- a/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
+++ b/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
@@ -1,0 +1,44 @@
+﻿using HarmonyLib;
+using PawnRules.Data;
+using RimWorld;
+using Verse;
+
+namespace PawnRules.Patch
+{
+    [HarmonyPatch(typeof(WorkGiver_FeedPatient), "JobOnThing")]
+    internal static class RimWorld_WorkGiver_FeedPatient_JobOnThing
+    {
+        private static void Prefix(Pawn pawn, Thing t)
+        {
+            if (!Registry.IsActive || !Registry.AllowRestingFood || !(t is Pawn) || ((t as Pawn).training is null)) { return; }
+
+            Registry.ExemptedTrainer = pawn;
+        }
+
+        private static void Postfix()
+        {
+            if (!Registry.IsActive || (Registry.ExemptedTrainer == null)) { return; }
+
+            Registry.ExemptedTrainer = null;
+        }
+    }
+
+    [HarmonyPatch(typeof(WorkGiver_FeedPatient), "HasJobOnThing")]
+    internal static class RimWorld_WorkGiver_FeedPatient_HasJobOnThing
+    {
+        private static void Prefix(Pawn pawn, Thing t)
+        {
+            if (!Registry.IsActive || !Registry.AllowRestingFood || !(t is Pawn) || ((t as Pawn).training is null)) { return; }
+
+            Registry.ExemptedTrainer = pawn;
+        }
+
+        private static void Postfix()
+        {
+            if (!Registry.IsActive || (Registry.ExemptedTrainer == null)) { return; }
+
+            Registry.ExemptedTrainer = null;
+        }
+    }
+
+}

--- a/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
+++ b/Source/Patch/RimWorld_WorkGiver_FeedPatient_JobOnThing.cs
@@ -48,14 +48,9 @@ namespace PawnRules.Patch
             if (t is Pawn)
             {
                 Pawn p = t as Pawn;
-                return (p.training != null) && (DoesPawnHaveImmunityDisease(p) || !CanPawnWalk(p));
+                return (p.training != null) && (HealthAIUtility.ShouldSeekMedicalRest(p) || !CanPawnWalk(p));
             }
             return false;
-        }
-
-        private static bool DoesPawnHaveImmunityDisease(Pawn p)
-        {
-            return p.health.hediffSet.HasImmunizableNotImmuneHediff();
         }
 
         private static bool CanPawnWalk(Pawn p)

--- a/Source/PawnRules.csproj
+++ b/Source/PawnRules.csproj
@@ -55,6 +55,7 @@
     <Compile Include="Patch\RimWorld_PawnColumnWorker_FoodRestriction_Compare.cs" />
     <Compile Include="Patch\RimWorld_PawnColumnWorker_FoodRestriction_DoAssignFoodRestrictionButtons.cs" />
     <Compile Include="Patch\RimWorld_PawnColumnWorker_FoodRestriction_DoHeader.cs" />
+    <Compile Include="Patch\RimWorld_WorkGiver_FeedPatient_JobOnThing.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Mod.cs" />
     <Compile Include="API\OptionHandle.cs" />


### PR DESCRIPTION
Add Option "Allow any food to sick resting animals"

![sickRestingAnimals](https://user-images.githubusercontent.com/7416299/98617354-d5c40c00-22cc-11eb-91a7-4827ccef3274.png)

# The Use Case

I've got lots of Hauling animals that are Grazing Herbivores. Think Horse/Donkey/Elephant/Megasloth/Thrumbo (I think).

I want them to be able to haul to the freezer, so I don't want to restrict it, and especially haul food grown in the fields into the freezer, so I don't want to restrict the fields either, but I also want them to eat live plants outside, not those food items.

Enter this mod. That's why I start using it. By setting them a Food Policy that is only live plants (and no items), they can be unrestricted, and go anywhere, without needing to micromanage their allowed areas, and trusting they'll eat all the right stuff.

# The First Case

As you know, the first case is Training, which is, obviously, why we already have option "Allow any food when training".

# The Second Case

But there's another case, which is when the animals get Flu, or Plague, or are heavily injured and cannot walk, and go lie down / are rescued into a sleeping spot. Now they need to be manually fed, and the mod starts to break down for similar reasons. The food items aren't in their policy.

We could add the items to the policy, but then healthy animals would eat them too. We could set "Allow any food when malnourished", but there are plenty of healthy stupid animals who fall asleep hungry. We don't want them eating from the freezer.

Enter this new option: "Allow any food to sick resting animals"